### PR TITLE
非同期通信によるメッセージ投稿の反映機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,9 +204,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    turbolinks (5.2.0)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -246,7 +243,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -36,6 +36,7 @@ $(function(){
       $(".main__chat__after").before(html);
       $(".main__chat").animate({scrollTop: $('.main__chat')[0].scrollHeight});
       $(".main__footer__output__form__textarea__text").val("");
+      $(".main__footer__output__form__textarea__picture--btn").val("");
       $(".main__footer__output__form__submit").prop("disabled", false);
     })
     .fail(function(){

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,6 @@
 $(function(){
   function buildHTML(message){
-    var input_imgtag = (message.image) ? `<img src=${message.image}></img>`: "";
+    var input_imgtag = (message.image) ? `<img src=${ message.image }></img>`: "";
     var html = `<div class ="main__chat__posts">
                   <div class="main__chat__posts__left">
                     <p class="main__chat__posts__left__username">
@@ -17,14 +17,14 @@ $(function(){
                     ${ input_imgtag }
                   </div>
                 </div>`
-        return html;          
+    return html;          
   }
   $(".new_message").on("submit",function(e){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr("action");
     $.ajax({
-      url:  url,
+      url: url,
       type: "POST",
       data: formData,
       dataType: "json",

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -4,17 +4,17 @@ $(function(){
     var html = `<div class ="main__chat__posts">
                   <div class="main__chat__posts__left">
                     <p class="main__chat__posts__left__username">
-                        ${ message.name }
-                      </p>
+                      ${ message.name }
+                    </p>
                     <p class="main__chat__posts__left__time">
-                        ${ message.time }
+                      ${ message.time }
                     </p>
                   </div>
                   <div class="main__chat__posts__bottom">
-                      <p class="main__chat__posts__bottom__text">
-                        ${ message.body }
-                      </p>
-                      ${ input_imgtag }
+                    <p class="main__chat__posts__bottom__text">
+                      ${ message.body }
+                    </p>
+                    ${ input_imgtag }
                   </div>
                 </div>`
         return html;          

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -4,10 +4,10 @@ $(function(){
     var html = `<div class ="main__chat__posts">
                   <div class="main__chat__posts__left">
                     <p class="main__chat__posts__left__username">
-                        ${ message.user_name }
+                        ${ message.name }
                       </p>
                     <p class="main__chat__posts__left__time">
-                        ${ message.created_at }
+                        ${ message.time }
                     </p>
                   </div>
                   <div class="main__chat__posts__bottom">
@@ -19,7 +19,7 @@ $(function(){
                 </div>`
         return html;          
   }
-  $("#new_message").on("submit",function(e){
+  $(".new_message").on("submit",function(e){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr("action");
@@ -27,20 +27,19 @@ $(function(){
       url:  url,
       type: "POST",
       data: formData,
-      dataType: 'json',
+      dataType: "json",
       contentType: false,
       processData: false
     })
-    .done(function(formData){
-      var html = buildHTML(formData);
+    .done(function(data){
+      var html = buildHTML(data);
       $(".main__chat__after").before(html);
       $(".main__chat").animate({scrollTop: $('.main__chat')[0].scrollHeight});
-      //空欄処理
       $(".main__footer__output__form__textarea__text").val("");
-      $(".main__footer__output__form__submit").prop('disabled', false);
+      $(".main__footer__output__form__submit").prop("disabled", false);
     })
     .fail(function(){
-      alert('投稿に失敗しました');
+      alert("投稿に失敗しました");
     });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,46 @@
+$(function(){
+  function buildHTML(message){
+    var input_imgtag = (message.image) ? `<img src=${message.image}></img>`: "";
+    var html = `<div class ="main__chat__posts">
+                  <div class="main__chat__posts__left">
+                    <p class="main__chat__posts__left__username">
+                        ${ message.user_name }
+                      </p>
+                    <p class="main__chat__posts__left__time">
+                        ${ message.created_at }
+                    </p>
+                  </div>
+                  <div class="main__chat__posts__bottom">
+                      <p class="main__chat__posts__bottom__text">
+                        ${ message.body }
+                      </p>
+                      ${ input_imgtag }
+                  </div>
+                </div>`
+        return html;          
+  }
+  $("#new_message").on("submit",function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr("action");
+    $.ajax({
+      url:  url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      contentType: false,
+      processData: false
+    })
+    .done(function(formData){
+      var html = buildHTML(formData);
+      $(".main__chat__after").before(html);
+      $(".main__chat").animate({scrollTop: $('.main__chat')[0].scrollHeight});
+      //空欄処理
+      $(".main__footer__output__form__textarea__text").val("");
+      $(".main__footer__output__form__submit").prop('disabled', false);
+    })
+    .fail(function(){
+      alert('投稿に失敗しました');
+    });
+  });
+});

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -75,6 +75,7 @@
           margin-right: 15px;
           position: relative;
           &__text{
+            box-sizing: border-box;
             line-height: 50px;
             padding-left: 10px;
             padding-right: 30px;
@@ -102,4 +103,7 @@
       }
     }
   }
+}
+.field_with_errors{
+  width: 100%;
 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,16 +3,15 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
-    respond_to do |format|
-      format.html
-      format.json
-    end  
-  end  
+  end    
 
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: "メッセージを送信しました"
+      respond_to do |format|
+        format.html{redirect_to group_messages_path(@group), notice: "メッセージを送信しました"}
+        format.json
+      end   
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = "メッセージを入力してください"

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,6 @@
 class MessagesController < ApplicationController
   before_action :set_group
+  
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,6 +3,10 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json
+    end  
   end  
 
   def create

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     %title ChatSpace
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
   %body
     = render partial: 'messages/flash_info'
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{content: "text/html; charset=UTF-8","http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application', media: 'all'
   %body
     = render partial: 'messages/flash_info'
     = yield

--- a/app/views/messages/_main_footer.html.haml
+++ b/app/views/messages/_main_footer.html.haml
@@ -1,6 +1,6 @@
 %div.main__footer
   %div.main__footer__output
-    = form_for [group, message] do |f|
+    = form_for [group, message], class: "form_message"  do |f|
       %div.main__footer__output__form
         %div.main__footer__output__form__textarea
           = f.text_field :body, class: "main__footer__output__form__textarea__text", placeholder: "type a message"

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.body @message.body
+json.user_name @message.user.name
+json.image  @message.image.url
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.group_id @message.group.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,6 @@
+
 json.body @message.body
-json.user_name @message.user.name
+json.name @message.user.name
 json.image  @message.image.url
-json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.time @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.group_id @message.group.id


### PR DESCRIPTION
# What

ChatSpaceアプリケーションのメッセージ機能において、メッセージ投稿後にajaxを用いて非同期通信を行い、投稿を非同期にて表示し、新規投稿箇所までスクロールする機能を実装した。
- /assests/jacvascriptsディレクトリにmessage.jsファイルを作成し、非同期でのメッセージ投稿反映に関する動作を記述した。
- /views/messagesディレクトリにcreate.json.jbuilderファイルを作成し、message.jsに渡す値の記述をした。
- 投稿エラー時に文字入力フォームのレイアウトが崩れていたため、/assests/stylesheets/_main.scssにエラー時に発生する<div class="field_with_errors">タグに対してレイアウト崩れを防止する記述を追加した。
- messages_controller.rbのcreateアクションにresopnd_toにて受け取った値がhtmlかjsonかで処理を分ける記述を追加した。

[追記]
- turbolinks使用時にページ内リンクを用いてページ遷移した直後の初回の１投稿のみ非同期通信が行われていなかったため、Gemfileのturbolinksの項目をコメントアウトし、各ファイルからturbolinks関連の記述を削除した。

# Why
非同期通信による新規メッセージの更新により、より完成度の高く使用感の良いアプリケーションを作成するため。